### PR TITLE
make clean-database now works without erasing everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean-image:
 	docker image rm our-frontend-image
 	docker image rm our-backend-image
 
-clean-database:
+clean-database: clean-postgresql
 	@if docker volume inspect $(VOLUME_DATA) 1>/dev/null 2>/dev/null ; then docker volume rm $(VOLUME_DATA); fi
 
 clean-postgresql:


### PR DESCRIPTION
The postgresql container is the one that used the database volume. 

Even if you stopped all containers, they can be restarted at any time and docker doesn't allow you to delete the volume of an existing container, whether it's awake or asleep.

Solution: before removing the volume, remove the container using it: **our-postgresql**

My first solution was to run docker-compose down before removing the volume, but that removes all the containers and the network, which may not be necessary when you just want to clean the db.

Feel free to propose changes if you have a better idea.