### PR TITLE
backend: link nestjs/cli

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ln --symbolic \
+ln -s \
   /app/node_modules/@nestjs/cli/bin/nest.js \
   /usr/local/bin/nest
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+ln --symbolic \
+  /app/node_modules/@nestjs/cli/bin/nest.js \
+  /usr/local/bin/nest
+
 npm install
 
 npm run build


### PR DESCRIPTION
# Backend: link nestjs/cli

I generate a symbolic link of the nest-cli into a `PATH` folder

## test

```bash
make cmd-back
nest --help
```

Nestjs/cli should print a help message

## see also

* `man 1 ln`
