### PR TITLE
frontend: update vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2804,9 +2804,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.5.tgz",
-            "integrity": "sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==",
+            "version": "4.3.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+            "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.17.5",


### PR DESCRIPTION
# frontend: update package

there is 1 high severity vulnerability printed in the log after execute `make`

I did this:
```
docker exec -it our-frontend sh
/app # npm audit

vite  4.3.0 - 4.3.8
Severity: high
Vite Server Options (server.fs.deny) can be bypassed using double forward-slash (//) - https://github.com/advisories/GHSA-353f-5xf4-qw67
fix available via `npm audit fix`
node_modules/vite

1 high severity vulnerability

To address all issues, run:
  npm audit fix
/app # npm audit fix

changed 1 package, and audited 214 packages in 3s

40 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
/app # exit
```
