### PR TITLE
Delete docker volume when make kill-your-work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ clean-back:
 kill-your-work:
 	docker container prune -f
 	docker image prune -a -f
-	docker volume prune -f
+	docker compose down --volumes
 	rm -rf ./frontend/node_modules
 	rm -rf ./backend/node_modules
 	rm -rf ./backend/dist


### PR DESCRIPTION
The command ```docker volume prune -f``` did not remove the docker volume **our-volume**, so I propose to use ```docker compose down --volumes``` instead.