### PR TITLE
user login is now user nickname

### DIFF
--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -20,32 +20,32 @@ export class AppService {
     async seed() {
         //  create Users
         const user1 = this.userRepo.create({
-            login: 'user1',
+            nickname: 'user1',
             avatarUrl: 'http://localhost:8080/api/user/picture/user1.webp',
         })
         await this.userRepo.save(user1)
         const user2 = this.userRepo.create({
-            login: 'user2',
+            nickname: 'user2',
             avatarUrl: 'http://localhost:8080/api/user/picture/user2.webp',
         })
         await this.userRepo.save(user2)
         const user3 = this.userRepo.create({
-            login: 'user3',
+            nickname: 'user3',
             avatarUrl: 'http://localhost:8080/api/user/picture/user3.webp',
         })
         await this.userRepo.save(user3)
         const user4 = this.userRepo.create({
-            login: 'user4',
+            nickname: 'user4',
             avatarUrl: 'http://localhost:8080/api/user/picture/user4.webp',
         })
         await this.userRepo.save(user4)
         const user5 = this.userRepo.create({
-            login: 'user5',
+            nickname: 'user5',
             avatarUrl: 'http://localhost:8080/api/user/picture/user5.webp',
         })
         await this.userRepo.save(user5)
         const user6 = this.userRepo.create({
-            login: 'user6',
+            nickname: 'user6',
             avatarUrl: 'http://localhost:8080/api/user/picture/user6.webp',
         })
         await this.userRepo.save(user6)

--- a/backend/src/typeorm/user.entity.ts
+++ b/backend/src/typeorm/user.entity.ts
@@ -19,7 +19,7 @@ export class User {
         unique: true,
         type: 'text',
     })
-    login: string
+    nickname: string
 
     @Column('text')
     avatarUrl: string

--- a/backend/src/user/dto/create-user.dto.ts
+++ b/backend/src/user/dto/create-user.dto.ts
@@ -2,7 +2,7 @@ import { IsNotEmpty, IsOptional } from 'class-validator'
 
 export class CreateUserDto {
     @IsNotEmpty()
-    login: string
+    nickname: string
 
     @IsNotEmpty()
     avatarUrl: string


### PR DESCRIPTION
This branch just changes User property login to nickname.

Why?

Because the user must be able to choose another name for himself, so at first, when the user login for the first time it will be its 42 login name and then it will possibly change to whatever he wants (but it must be unique).

Why not first_name as we talk together (with Samuel and Emiliano)?

Because it must be unique, and 42 logins are unique but first_name are not.