### PR TITLE
frontend: remove import react

### DIFF
--- a/frontend/src/components/profile/ClickableIcon.tsx
+++ b/frontend/src/components/profile/ClickableIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styles from './ClickableIcon.module.css'
 
 interface ClickableIconProps {

--- a/frontend/src/components/profile/Friend.tsx
+++ b/frontend/src/components/profile/Friend.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styles from './Friend.module.css'
 import IconAddFriend from '../../assets/icon/add_friend.svg'
 import IconRemoveFriend from '../../assets/icon/remove_friend.svg'

--- a/frontend/src/components/profile/StatisticElement.tsx
+++ b/frontend/src/components/profile/StatisticElement.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styles from './StatisticElement.module.css'
 
 interface StatisticElement {

--- a/frontend/src/components/profile/UserInformation.tsx
+++ b/frontend/src/components/profile/UserInformation.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styles from './UserInformation.module.css'
 import ClickableIcon from './ClickableIcon'
 import IconEditProfile from '../../assets/icon/edit_profile.svg'


### PR DESCRIPTION
# Frontend: remove import React

## Why?

because when we build the frontend we
receive this error:

```
src/components/profile/ClickableIcon.tsx(1,1): error TS6133: 'React' is declared but its value is never read.
src/components/profile/Friend.tsx(1,1): error TS6133: 'React' is declared but its value is never read.
src/components/profile/StatisticElement.tsx(1,1): error TS6133: 'React' is declared but its value is never read.
src/components/profile/UserInformation.tsx(1,1): error TS6133: 'React' is declared but its value is never read.
```

## command used:

```bash
sed -i \
':a;N;$!ba;s/import React from .react.\n//g' \
$(find frontend/src/components/profile -type f)
```

## sed: replace newline

* [how-can-i-replace-each-newline-n-with-a-space-using-sed](https://stackoverflow.com/questions/1251999/how-can-i-replace-each-newline-n-with-a-space-using-sed)
