### PR TITLE
R profile refactor

### DIFF
--- a/frontend/src/components/profile/Statistics.tsx
+++ b/frontend/src/components/profile/Statistics.tsx
@@ -3,9 +3,12 @@ import StatisticElement from './StatisticElement'
 import IconVictoire from '../../assets/icon/victoires.svg'
 import IconDefeat from '../../assets/icon/defeats.svg'
 import IconRanking from '../../assets/icon/ranking.svg'
-import { UserInformationProps } from '../../pages/MainProfile'
+import { useAppSelector } from '../../store/types'
+import { UserData } from '../../types/UserData'
 
-const Statistics = ({ userData }: UserInformationProps) => {
+const Statistics = () => {
+    const userData = useAppSelector((state) => state.user.userData) as UserData
+
     return (
         <div>
             <div className={styles.container}>
@@ -35,3 +38,4 @@ const Statistics = ({ userData }: UserInformationProps) => {
 }
 
 export default Statistics
+

--- a/frontend/src/components/profile/Statistics.tsx
+++ b/frontend/src/components/profile/Statistics.tsx
@@ -38,4 +38,3 @@ const Statistics = () => {
 }
 
 export default Statistics
-

--- a/frontend/src/components/profile/UserInformation.tsx
+++ b/frontend/src/components/profile/UserInformation.tsx
@@ -12,11 +12,6 @@ const UserInformation = () => {
     const userData = useAppSelector((state) => state.user.userData) as UserData
     const [TFAEnabled, setTFAEnabled] = useState(userData.user.TFAEnabled)
 
-    const profilePictureStyle = {
-        backgroundImage: `url(${userData.user.avatarUrl})`,
-        backgroundSize: 'cover',
-    }
-
     const editProfile = () => {
         // TODO implement this functionality in both the frontend and the backend
         console.log('Edit Profile')
@@ -48,7 +43,7 @@ const UserInformation = () => {
         <div className={styles.container}>
             <div
                 className={styles.profilePicture}
-                style={profilePictureStyle}
+                style={{ backgroundImage: `url(${userData.user.avatarUrl})`, backgroundSize: 'cover' }}
             ></div>
             <div>
                 <ul className={styles.verticalList}>

--- a/frontend/src/components/profile/UserInformation.tsx
+++ b/frontend/src/components/profile/UserInformation.tsx
@@ -1,11 +1,15 @@
 import styles from './UserInformation.module.css'
 import ClickableIcon from './ClickableIcon'
 import IconEditProfile from '../../assets/icon/edit_profile.svg'
-import { UserInformationProps } from '../../pages/MainProfile'
 import switchButtonStyles from './SwitchButton.module.css'
 import { useState } from 'react'
+import { useAppSelector } from '../../store/types'
+import { UserData } from '../../types/UserData'
 
-const UserInformation = ({ userData }: UserInformationProps) => {
+
+
+const UserInformation = () => {
+    const userData = useAppSelector((state) => state.user.userData) as UserData
     const [TFAEnabled, setTFAEnabled] = useState(userData.user.TFAEnabled)
 
     const profilePictureStyle = {

--- a/frontend/src/components/profile/UserInformation.tsx
+++ b/frontend/src/components/profile/UserInformation.tsx
@@ -6,8 +6,6 @@ import { useState } from 'react'
 import { useAppSelector } from '../../store/types'
 import { UserData } from '../../types/UserData'
 
-
-
 const UserInformation = () => {
     const userData = useAppSelector((state) => state.user.userData) as UserData
     const [TFAEnabled, setTFAEnabled] = useState(userData.user.TFAEnabled)
@@ -43,7 +41,10 @@ const UserInformation = () => {
         <div className={styles.container}>
             <div
                 className={styles.profilePicture}
-                style={{ backgroundImage: `url(${userData.user.avatarUrl})`, backgroundSize: 'cover' }}
+                style={{
+                    backgroundImage: `url(${userData.user.avatarUrl})`,
+                    backgroundSize: 'cover',
+                }}
             ></div>
             <div>
                 <ul className={styles.verticalList}>

--- a/frontend/src/pages/MainProfile.tsx
+++ b/frontend/src/pages/MainProfile.tsx
@@ -4,27 +4,22 @@ import FriendList from '../components/profile/FriendList'
 import Statistics from '../components/profile/Statistics'
 import UserInformation from '../components/profile/UserInformation'
 import { userActions } from '../store/user'
-import { useAppDispatch, useAppSelector } from '../store/types'
+import { useAppDispatch } from '../store/types'
 import { UserData } from '../types/UserData'
 import { useLoaderData } from 'react-router-dom'
-
-export interface UserInformationProps {
-    userData: UserData
-}
 
 const MainProfile = () => {
     const fetchUserData = useLoaderData() as UserData
     const dispatch = useAppDispatch()
     dispatch(userActions.update({ user: fetchUserData }))
 
-    const userData = useAppSelector((state) => state.user.userData) as UserData
     return (
         <div className={styles.container}>
             <h1>Profile</h1>
             <div className={styles.body}>
                 <div className={styles.bodyLeftSide}>
-                    <UserInformation userData={userData} />
-                    <Statistics userData={userData} />
+                    <UserInformation />
+                    <Statistics />
                     <SeeMatchHistoryBtn />
                 </div>
                 <div className={styles.bodyRightSide}>


### PR DESCRIPTION
This is a small refactoring.
There was a problem sometimes when ```<MainProfile />``` was re-rending, a inifinite loop was created with the store.
Now the store is update with the data from the loader and nothing more.

Statistics.tsx and UserInformation.tsx don't get props anymore but they each fetch the data they need in the store directly. 