### PR TITLE
UserLambda hotfix

### DIFF
--- a/frontend/src/components/profile/StatisticsLambda.tsx
+++ b/frontend/src/components/profile/StatisticsLambda.tsx
@@ -1,0 +1,37 @@
+import styles from './Statistics.module.css'
+import StatisticElement from './StatisticElement'
+import IconVictoire from '../../assets/icon/victoires.svg'
+import IconDefeat from '../../assets/icon/defeats.svg'
+import IconRanking from '../../assets/icon/ranking.svg'
+import { UserInformationProps } from '../../pages/MainProfile'
+
+const StatisticsLambda = ({ userData }: UserInformationProps) => {
+    return (
+        <div>
+            <div className={styles.container}>
+                <div className={styles.subtitle}>Statistics</div>
+                <div className={styles.horizontalList}>
+                    <StatisticElement
+                        icon={IconVictoire}
+                        text="Victorires"
+                        number={userData.user.nbVictory}
+                    />
+                    <StatisticElement
+                        icon={IconDefeat}
+                        text="Defeats"
+                        number={
+                            userData.user.totalPlay - userData.user.nbVictory
+                        }
+                    />
+                    <StatisticElement
+                        icon={IconRanking}
+                        text="Ranking"
+                        number={userData.user.userPosition}
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default StatisticsLambda

--- a/frontend/src/pages/UserLambda.tsx
+++ b/frontend/src/pages/UserLambda.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import styles from './MainProfile.module.css'
-import Statistics from '../components/profile/Statistics'
+import StatisticsLambda from '../components/profile/StatisticsLambda'
 import UserLambdaInformation from '../components/UserLambda/UserLambdaInformation'
 import { UserData } from '../types/UserData'
 
@@ -43,7 +43,7 @@ const UserLambda = () => {
             <div className={styles.body}>
                 <div className={styles.bodyLeftSide}>
                     <UserLambdaInformation userData={userData} />
-                    <Statistics userData={userData} />
+                    <StatisticsLambda userData={userData} />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The functionality did not work because the
element was based on an old version of the
'statistics' element.

Hotfix: recreate the old element and call it 
StatisticsLambda.

How to test it? In the Stage branch try to 
access localhost:4040/user/user1 and you 
will see that it does not work. 

This pull request allows localhost:
4040/user/user1 to work correctly.

Thanks @fire-poy  for finding it, reporting
it and find the cause.