### PR TITLE
frontend: profile add link on the username

### DIFF
--- a/frontend/src/components/profile/Friend.tsx
+++ b/frontend/src/components/profile/Friend.tsx
@@ -4,6 +4,34 @@ import IconRemoveFriend from '../../assets/icon/remove_friend.svg'
 import IconGenericPicture from '../../assets/icon/generic_picture.svg'
 import ClickableIcon from './ClickableIcon'
 
+import {
+    Routes,
+    Route,
+    Outlet,
+    Link,
+    useMatch,
+    useResolvedPath,
+} from 'react-router-dom'
+import type { LinkProps } from 'react-router-dom'
+
+function CustomLink({ children, to, ...props }: LinkProps) {
+    let resolved = useResolvedPath(to)
+    let match = useMatch({ path: resolved.pathname, end: true })
+
+    return (
+        <div>
+            <Link
+                style={{ textDecoration: match ? 'underline' : 'none' }}
+                to={to}
+                {...props}
+            >
+                {children}
+            </Link>
+            {match && ' (active)'}
+        </div>
+    )
+}
+
 export interface FriendProps {
     id: number
     name: string
@@ -76,7 +104,9 @@ const Friend = ({ name, picture, status, isFriend }: FriendProps) => {
                 style={profilePictureStyle}
             ></div>
             <div className={styles.nameAndStatus}>
-                <h3>{name}</h3>
+                <CustomLink to={`/user/${name}`}>
+                    <h3>{name}</h3>
+                </CustomLink>
                 <p className={`${styles.status} ${statusColorClass}`}>
                     {status}
                 </p>

--- a/frontend/src/components/profile/Friend.tsx
+++ b/frontend/src/components/profile/Friend.tsx
@@ -4,14 +4,7 @@ import IconRemoveFriend from '../../assets/icon/remove_friend.svg'
 import IconGenericPicture from '../../assets/icon/generic_picture.svg'
 import ClickableIcon from './ClickableIcon'
 
-import {
-    Routes,
-    Route,
-    Outlet,
-    Link,
-    useMatch,
-    useResolvedPath,
-} from 'react-router-dom'
+import { Link, useMatch, useResolvedPath } from 'react-router-dom'
 import type { LinkProps } from 'react-router-dom'
 
 function CustomLink({ children, to, ...props }: LinkProps) {


### PR DESCRIPTION
# frontend: profile add link on the username

add a link to `/user/${username}` on the name of the user

## Resources

Code [example of custom link](https://github.com/remix-run/react-router/blob/dev/examples/custom-link/src/App.tsx)

I started with this
[use link props](https://reactnavigation.org/docs/use-link-props/#options)
but we use react router and not
reactnavigation

## TODO

* [x] wait on #77
* [x] wait on #79

## Try

Click on the username on a friend in the friendlist
