### PR TITLE
Global usage of authenticated.guard

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,8 @@ import { Match } from './typeorm/match.entity'
 import { FriendModule } from './friend/friend.module'
 import { MatchModule } from './match/match.module'
 import { AuthModule } from './auth/auth.module'
+import { AuthenticatedGuard } from './auth/guards/authenticated.guard'
+import { APP_GUARD } from '@nestjs/core'
 
 @Module({
     imports: [
@@ -34,6 +36,12 @@ import { AuthModule } from './auth/auth.module'
         AuthModule,
     ],
     controllers: [AppController],
-    providers: [AppService],
+    providers: [
+        AppService,
+        {
+            provide: APP_GUARD,
+            useClass: AuthenticatedGuard,
+        },
+    ],
 })
 export class AppModule {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -11,10 +11,10 @@ import {
 import { OauthGuard } from './guards/oauth.guard'
 import { ApiTags } from '@nestjs/swagger'
 import { AuthService } from './auth.service'
-import { AuthenticatedGuard } from './guards/authenticated.guard'
 import { TotpGuard } from './guards/totp.guard'
 import { Activate2faGuard } from './guards/activate2fa.guard'
 import { UserService } from 'src/user/user.service'
+import { Public } from 'src/decorators/public.decorator'
 
 @ApiTags('auth')
 @Controller('auth')
@@ -24,10 +24,12 @@ export class AuthController {
         private readonly userService: UserService
     ) {}
 
+    @Public()
     @Get('42')
     @UseGuards(OauthGuard)
     async login() {}
 
+    @Public()
     @Get('42/redirect')
     @UseGuards(OauthGuard)
     loginRedirect(@Req() req, @Res() res) {
@@ -38,29 +40,33 @@ export class AuthController {
         return req.user
     }
 
+    @Public()
     @Get('loginStatus')
     getStatus(@Req() req) {
         return this.userService.logStatus(req)
     }
 
+    @Public()
     @Post('2fa/turn-on')
     @UseGuards(Activate2faGuard)
     async activate2fa(@Request() req: any, @Body() body) {
         return await this.authService.activate2fa(req, body)
     }
 
+    @Public()
     @Post('2fa/turn-off')
-    @UseGuards(AuthenticatedGuard)
     async deactivate2fa(@Request() req: any) {
         return await this.authService.deactivate2fa(req)
     }
 
+    @Public()
     @Post('2fa/authenticate')
     @UseGuards(TotpGuard)
     async authenticateTOTP(@Request() req: any, @Body() body) {
         return await this.authService.authenticateTOTP(req, body)
     }
 
+    @Public()
     @Get('2fa/generate')
     @UseGuards(Activate2faGuard)
     async generateQR(@Request() req: any) {

--- a/backend/src/auth/guards/authenticated.guard.ts
+++ b/backend/src/auth/guards/authenticated.guard.ts
@@ -1,8 +1,19 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import { IS_PUBLIC_KEY } from 'src/decorators/public.decorator'
 
 @Injectable()
 export class AuthenticatedGuard implements CanActivate {
+    constructor(private reflector: Reflector) {}
+
     async canActivate(context: ExecutionContext) {
+        const isPublic = this.reflector.getAllAndOverride<boolean>(
+            IS_PUBLIC_KEY,
+            [context.getHandler(), context.getClass()]
+        )
+        if (isPublic) {
+            return true
+        }
         const request = context.switchToHttp().getRequest()
 
         return request.isAuthenticated() && request.session.needTFA === false

--- a/backend/src/decorators/public.decorator.ts
+++ b/backend/src/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common'
+
+export const IS_PUBLIC_KEY = 'isPublic'
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true)

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -23,11 +23,10 @@ import { ApiTags } from '@nestjs/swagger'
 import { FileInterceptor } from '@nestjs/platform-express'
 import { diskStorage } from 'multer'
 import { UpdateNicknameDto } from './dto/update-nickname.dto'
-import { UseGuards } from '@nestjs/common'
-import { AuthenticatedGuard } from 'src/auth/guards/authenticated.guard'
 import { v4 as uuidv4 } from 'uuid'
 import { extname } from 'path'
 import { Response } from 'express'
+import { Public } from 'src/decorators/public.decorator'
 
 @ApiTags('user')
 @Controller('user')
@@ -110,6 +109,7 @@ export class UserController {
         res.sendFile(filename, { root: './uploads' })
     }
 
+    @Public()
     @Get('me')
     async getUser(@Request() req: any) {
         const user = await this.userService.findOne(req.user.id)
@@ -124,7 +124,6 @@ export class UserController {
     }
 
     @Get('nickname/:nickname')
-    @UseGuards(AuthenticatedGuard)
     async getLambda(@Param('nickname') nickname: string) {
         return await this.userService.getLambdaInfo(nickname)
     }


### PR DESCRIPTION
The 'authenticated.guard' guard is now used globally throughout the backend. If you want it not to be used on a certain endpoint you must use the @Public decorator.

Docs:
https://docs.nestjs.com/security/authentication#enable-authentication-globally