### PR TITLE
warning when reloading profile fix

### DIFF
--- a/frontend/src/pages/MainProfile.tsx
+++ b/frontend/src/pages/MainProfile.tsx
@@ -3,11 +3,9 @@ import FriendList from '../components/profile/FriendList'
 import Statistics from '../components/profile/Statistics'
 import UserInformation from '../components/profile/UserInformation'
 import { userActions } from '../store/user'
-import { useAppDispatch } from '../store/types'
-import { UserData } from '../types/UserData'
-import { useLoaderData } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import AddFriendsBtn from '../components/profile/AddFriendsBtn'
+import store from '../store'
 
 export interface friendList {
     myId: number
@@ -44,9 +42,6 @@ const MainProfile = () => {
     })
 
     const refreshTime: number = 3000
-    const fetchUserData = useLoaderData() as UserData
-    const dispatch = useAppDispatch()
-    dispatch(userActions.update({ user: fetchUserData }))
 
     const [isLoading, setIsLoading] = useState(true)
 
@@ -158,5 +153,6 @@ export async function loader() {
     }
 
     const data = await response.json()
+    store.dispatch(userActions.update({ user: data }))
     return data
 }


### PR DESCRIPTION
Here is a fix for this warning when reloading /profile.
<img width="1428" alt="Screenshot 2023-07-25 at 13 32 12" src="https://github.com/eprei/ft_transcendence/assets/68509729/9487dfb7-bc1f-492f-a306-ed2e980431fa">

What is going on?
the loader is fetching user before rendering but the user is updated on the component rendering like that:
```
    const fetchUserData = useLoaderData() as UserData
    const dispatch = useAppDispatch()
    dispatch(userActions.update({ user: fetchUserData }))
```
because you cannot use react Hooks outside of react components.

The problem is that UserInformation is trying to fetch userData from the store at the (almost) same time that it is being updated.

Solution:
in the loader you can use :
```
store.dispatch(userActions.update({ user: data }))
```
to update user before rendering and store.dispatch() is not a react Hook.