### PR TITLE
backend: ignore env file

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,7 +21,7 @@ import { RoomModule } from './room/room.module'
 
 @Module({
     imports: [
-        ConfigModule.forRoot({ isGlobal: true }),
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
         TypeOrmModule.forRoot({
             type: 'postgres',
             url: process.env.DATABASE_URL,


### PR DESCRIPTION
# Backend: ignore `.env` file

## Why ?

It is, IMHO, a security improvement,
that avoids to set a env file by error

## Resource

* https://docs.nestjs.com/techniques/configuration#disable-env-variables-loading
