### PR TITLE
E delete @Public decorator from 'room' controller

### DIFF
--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -12,11 +12,9 @@ import {
 } from '@nestjs/common'
 import { RoomService } from './room.service'
 import { Room } from 'src/types/Room'
-import { Public } from '../decorators/public.decorator'
 import { ApiTags } from '@nestjs/swagger'
 import { CreateRoomDto } from './dto/create-room.dto'
 
-@Public()
 @ApiTags('room')
 @Controller('room')
 export class RoomController {


### PR DESCRIPTION
Normally, the only endpoints that use the 
@Public decorator are the ones that we do 
not want to protect with the general 
guard. 

Since this is not the case for this group 
of endpoints, we must delete the 
decorator. 

I forgot to delete it at the end of the 
tests and before doing the last PR.