### PR TITLE
Pong: save match in data base and improvement of coalition logic

### DIFF
--- a/backend/src/match/dto/create-match.dto.ts
+++ b/backend/src/match/dto/create-match.dto.ts
@@ -3,20 +3,14 @@ import { User } from '../../typeorm/user.entity'
 
 export class CreateMatchDto {
     @IsNotEmpty()
-    userHome: User
-
-    @IsNotEmpty()
-    userForeign: User
-
-    @IsNotEmpty()
     winner: User
 
     @IsNotEmpty()
-    homeScore: number
+    loser: User
 
     @IsNotEmpty()
-    foreignScore: number
+    scoreWinner: number
 
-    @IsOptional()
-    timestamp: Date
+    @IsNotEmpty()
+    scoreLoser: number
 }

--- a/backend/src/pong/pong.gateway.ts
+++ b/backend/src/pong/pong.gateway.ts
@@ -78,14 +78,12 @@ export class PongGateway
     }
 
     @SubscribeMessage('leaveRoom')
-    handleLeaveRoom(client: Socket, data: { userId: number }) {
-        const { userId } = data
-        const roomId = client.rooms[0]
+    handleLeaveRoom(client: Socket, data: { roomId: string; userId: number }) {
+        const { roomId, userId } = data
         client.leave(roomId)
-        client.emit('leftRoom', roomId)
+        this.server.to(roomId).emit('leftRoom')
         this.loger.log(`Client socket ${client.id} left room: ${roomId}`)
         this.userService.changeStatusOnLine(userId)
-        // TODO notify other player that the game is over and manage the game state and the frontend
         // TODO delete the room from room service if it only has one player !!!
     }
 

--- a/backend/src/pong/pong.gateway.ts
+++ b/backend/src/pong/pong.gateway.ts
@@ -84,7 +84,6 @@ export class PongGateway
         this.server.to(roomId).emit('leftRoom')
         this.loger.log(`Client socket ${client.id} left room: ${roomId}`)
         this.userService.changeStatusOnLine(userId)
-        // TODO delete the room from room service if it only has one player !!!
     }
 
     private startGame(roomId: string) {

--- a/backend/src/pong/pong.gateway.ts
+++ b/backend/src/pong/pong.gateway.ts
@@ -142,6 +142,5 @@ export class PongGateway
         delete this.secondPlayerIds[roomId]
         this.userService.changeStatusOnLine(userId)
         client.leave(roomId)
-        // TODO add info to the match table to 'match history' feature
     }
 }

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -116,7 +116,7 @@ export class PongService {
             this.BALL_SPEED_Y *= -1
         }
 
-        // COALITION LOGIQUE
+        // COALITION LOGIC
         // left paddle
         if (
             this.frame.ball.position.x <=

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -152,20 +152,10 @@ export class PongService {
             this.frame.ball.position.x = FRAME_WIDTH / 2
             this.frame.ball.position.y = FRAME_HEIGHT / 2
             this.frame.score.playerOne += 1
-            if (this.frame.score.playerOne >= TOP_SCORE) {
-                this.frame.gameOver = true
-                this.frame.score.playerOne = 0
-                this.frame.score.playerTwo = 0
-            }
         } else if (this.frame.ball.position.x <= 0) {
             this.frame.ball.position.x = FRAME_WIDTH / 2
             this.frame.ball.position.y = FRAME_HEIGHT / 2
             this.frame.score.playerTwo += 1
-            if (this.frame.score.playerTwo >= TOP_SCORE) {
-                this.frame.gameOver = true
-                this.frame.score.playerOne = 0
-                this.frame.score.playerTwo = 0
-            }
         }
 
         if (

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -5,7 +5,7 @@ const FRAME_WIDTH: number = 300
 const FRAME_HEIGHT: number = 150
 const PADDLE_WIDTH: number = 2
 const PADDLE_HEIGHT: number = 30
-const TOP_SCORE: number = 3
+const TOP_SCORE: number = 10
 
 @Injectable()
 export class PongService {
@@ -117,31 +117,29 @@ export class PongService {
         }
 
         // COALITION LOGIQUE
-        // TODO improve the calculation of coalition with the paddle to make it more accurate
-        // probably eliminating this.BALL_SIZE from the equation or modifiyng it
+        // left paddle
         if (
             this.frame.ball.position.x <=
                 this.frame.paddleLeft.position.x + PADDLE_WIDTH &&
-            this.frame.ball.position.y + this.BALL_SIZE >=
-                this.frame.paddleLeft.position.y + this.BALL_SIZE &&
-            this.frame.ball.position.y <=
-                this.frame.paddleLeft.position.y +
-                    PADDLE_HEIGHT -
-                    this.BALL_SIZE
+            this.frame.ball.position.y + this.BALL_SIZE / 2 >=
+                this.frame.paddleLeft.position.y &&
+            this.frame.ball.position.y + this.BALL_SIZE / 2 <=
+                this.frame.paddleLeft.position.y + PADDLE_HEIGHT &&
+            this.frame.ball.position.x >= this.frame.paddleLeft.position.x
         ) {
             this.BALL_SPEED_X *= -1
             // Adjust the ball's position to be outside of the paddle
             this.frame.ball.position.x =
                 this.frame.paddleLeft.position.x + PADDLE_WIDTH
+            // right paddle
         } else if (
             this.frame.ball.position.x + this.BALL_SIZE >=
                 this.frame.paddleRight.position.x &&
-            this.frame.ball.position.y + this.BALL_SIZE >=
-                this.frame.paddleRight.position.y + this.BALL_SIZE &&
-            this.frame.ball.position.y <=
-                this.frame.paddleRight.position.y +
-                    PADDLE_HEIGHT -
-                    this.BALL_SIZE
+            this.frame.ball.position.y + this.BALL_SIZE / 2 >=
+                this.frame.paddleRight.position.y &&
+            this.frame.ball.position.y + this.BALL_SIZE / 2 <=
+                this.frame.paddleRight.position.y + PADDLE_HEIGHT &&
+            this.frame.ball.position.x <= this.frame.paddleRight.position.x
         ) {
             this.BALL_SPEED_X *= -1
             // Adjust the ball's position to be outside of the paddle
@@ -154,7 +152,7 @@ export class PongService {
             this.frame.ball.position.x = FRAME_WIDTH / 2
             this.frame.ball.position.y = FRAME_HEIGHT / 2
             this.frame.score.playerOne += 1
-            if (this.frame.score.playerOne >= 10) {
+            if (this.frame.score.playerOne >= TOP_SCORE) {
                 this.frame.gameOver = true
                 this.frame.score.playerOne = 0
                 this.frame.score.playerTwo = 0
@@ -163,7 +161,7 @@ export class PongService {
             this.frame.ball.position.x = FRAME_WIDTH / 2
             this.frame.ball.position.y = FRAME_HEIGHT / 2
             this.frame.score.playerTwo += 1
-            if (this.frame.score.playerTwo >= 10) {
+            if (this.frame.score.playerTwo >= TOP_SCORE) {
                 this.frame.gameOver = true
                 this.frame.score.playerOne = 0
                 this.frame.score.playerTwo = 0

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -116,7 +116,7 @@ export class PongService {
             this.BALL_SPEED_Y *= -1
         }
 
-        // COALITION LOGIC
+        // COLLISION LOGIC
         // left paddle
         if (
             this.frame.ball.position.x <=

--- a/backend/src/pong/pong.service.ts
+++ b/backend/src/pong/pong.service.ts
@@ -11,7 +11,6 @@ const TOP_SCORE: number = 3
 export class PongService {
     BALL_SIZE: number = 2
     PADDLE_SPEED: number = 2
-    // TODO Adjust the speed of the ball according to the processing capacity of the school's computers
     BALL_SPEED_Y: number = 1
     BALL_SPEED_X: number = 1
 
@@ -179,7 +178,6 @@ export class PongService {
             this.frame.gameOver = true
             return
         }
-        // TODO add info to the match table to 'match history' feature
     }
 
     getFrame(): Frame {

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -9,6 +9,7 @@ import {
     Request,
     HttpException,
     HttpStatus,
+    Delete,
 } from '@nestjs/common'
 import { RoomService } from './room.service'
 import { Room } from 'src/types/Room'
@@ -56,5 +57,10 @@ export class RoomController {
         } catch (error) {
             throw new HttpException(error.message, HttpStatus.CONFLICT)
         }
+    }
+
+    @Delete('id/:roomId')
+    deleteRoom(@Param('roomId') roomId: string) {
+        return this.roomService.deleteRoom(roomId)
     }
 }

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -81,11 +81,6 @@ export class RoomService {
     deleteRoom(room_id: string): Room | null {
         const index = this.rooms.findIndex((room) => room.room_id === room_id)
         if (index !== -1) {
-            console.log('room deleted', room_id)
-        } else {
-            console.log('room not found', room_id)
-        }
-        if (index !== -1) {
             return this.rooms.splice(index, 1)[0]
         }
         return null
@@ -114,8 +109,6 @@ export class RoomService {
             index = this.rooms.findIndex((room) => room.player_two === 0)
             if (index !== -1) {
                 this.rooms[index].player_two = myId
-                console.log('room found: ', this.rooms[index].room_id)
-                this.printRooms(this.rooms)
                 return this.rooms[index]
             }
             await this.sleep(1000)

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -51,8 +51,6 @@ export class RoomService {
         }
 
         this.rooms.push(room)
-        console.log('createRoom method from room.service has been called')
-        this.printRooms(this.rooms)
 
         return room
     }
@@ -82,8 +80,6 @@ export class RoomService {
 
     deleteRoom(room_id: string): Room | null {
         const index = this.rooms.findIndex((room) => room.room_id === room_id)
-        console.log('deleteRoom method from room.service has been called')
-        this.printRooms(this.rooms)
         if (index !== -1) {
             console.log('room deleted', room_id)
         } else {

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -15,7 +15,7 @@ export class RoomService {
         private readonly userService: UserService
     ) {}
 
-    private readonly rooms: Room[] = []
+    private rooms: Room[] = []
 
     getAllRooms(): Room[] {
         return this.rooms
@@ -51,6 +51,8 @@ export class RoomService {
         }
 
         this.rooms.push(room)
+        console.log('createRoom method from room.service has been called')
+        this.printRooms(this.rooms)
 
         return room
     }
@@ -66,10 +68,27 @@ export class RoomService {
         return null
     }
 
-    deleteRoom(id: number): Room {
-        const index = this.rooms.findIndex(
-            (room) => room.player_one === id || room.player_two === id
-        )
+    printRooms(rooms: Room[]): void {
+        console.log('List of rooms:')
+        rooms.forEach((room, index) => {
+            console.log(`Room ${index + 1}:`)
+            console.log(`Player One: ${room.player_one}`)
+            console.log(`Player Two: ${room.player_two}`)
+            console.log(`Theme: ${room.theme}`)
+            console.log(`Room ID: ${room.room_id}`)
+            console.log('---------------------')
+        })
+    }
+
+    deleteRoom(room_id: string): Room | null {
+        const index = this.rooms.findIndex((room) => room.room_id === room_id)
+        console.log('deleteRoom method from room.service has been called')
+        this.printRooms(this.rooms)
+        if (index !== -1) {
+            console.log('room deleted', room_id)
+        } else {
+            console.log('room not found', room_id)
+        }
         if (index !== -1) {
             return this.rooms.splice(index, 1)[0]
         }
@@ -99,6 +118,8 @@ export class RoomService {
             index = this.rooms.findIndex((room) => room.player_two === 0)
             if (index !== -1) {
                 this.rooms[index].player_two = myId
+                console.log('room found: ', this.rooms[index].room_id)
+                this.printRooms(this.rooms)
                 return this.rooms[index]
             }
             await this.sleep(1000)

--- a/frontend/src/components/pong/BoardGame.tsx
+++ b/frontend/src/components/pong/BoardGame.tsx
@@ -196,10 +196,26 @@ const BoardGame = ({
                     async function saveMatch() {
                         try {
                             const createMatchDto = {
-                                winner: player_one,
-                                loser: player_two,
-                                scoreWinner: updatedFrame.score.playerOne,
-                                scoreLoser: updatedFrame.score.playerTwo,
+                                winner:
+                                    updatedFrame.score.playerOne >
+                                    updatedFrame.score.playerTwo
+                                        ? player_one
+                                        : player_two,
+                                loser:
+                                    updatedFrame.score.playerOne >
+                                    updatedFrame.score.playerTwo
+                                        ? player_two
+                                        : player_one,
+                                scoreWinner:
+                                    updatedFrame.score.playerOne >
+                                    updatedFrame.score.playerTwo
+                                        ? updatedFrame.score.playerOne
+                                        : updatedFrame.score.playerTwo,
+                                scoreLoser:
+                                    updatedFrame.score.playerOne >
+                                    updatedFrame.score.playerTwo
+                                        ? updatedFrame.score.playerTwo
+                                        : updatedFrame.score.playerOne,
                             }
                             console.log(
                                 'createMatchDto front: ',

--- a/frontend/src/components/pong/BoardGame.tsx
+++ b/frontend/src/components/pong/BoardGame.tsx
@@ -49,8 +49,6 @@ export interface BoardGameProps {
 
 async function deleteRoomFromMatchingSystem(room: string) {
     try {
-        console.log('function deleteRoomFromMatchingSystem')
-        console.log('timestamp: ' + Date.now())
         const response = await fetch(
             `http://localhost:8080/api/room/id/${room}`,
             {
@@ -90,7 +88,6 @@ const BoardGame = ({
     const matchSaved = useRef<boolean>(false)
     const gameOver = useRef<boolean>(false)
     const otherPlayerHasLeftTheRoom = useRef<boolean>(false)
-    const isUnmounted = useRef(false)
 
     const [frame, setFrame] = useState<Frame>({
         paddleLeft: {
@@ -284,7 +281,6 @@ const BoardGame = ({
         socket.on('leftRoom', onSecondPlayerLeftTheRoom)
 
         function onSecondPlayerLeftTheRoom() {
-            console.log('The other player left the room')
             otherPlayerHasLeftTheRoom.current = true
             setTimeout(() => {
                 navigate('/play')
@@ -293,7 +289,6 @@ const BoardGame = ({
 
         const handleDeleteRoom = async () => {
             try {
-                console.log('DELETE room from matching system')
                 await deleteRoomFromMatchingSystem(room)
             } catch (error) {
                 console.error(error)
@@ -302,10 +297,9 @@ const BoardGame = ({
 
         return () => {
             // Remove the event listener when disassembling the component to avoid memory leaks
-            isUnmounted.current = true
             document.removeEventListener('keydown', handleKeyDown)
 
-            if (isUnmounted.current) {
+            if (imPlayerOne === true) {
                 handleDeleteRoom()
             }
 
@@ -321,7 +315,10 @@ const BoardGame = ({
             socket.off('waitingForSecondPlayer')
             socket.off('leftRoom', onSecondPlayerLeftTheRoom)
 
-            socket.close()
+            // TODO MOVE UP IN THE HIERARCHY THE SOCKET DECLARATION AND MANAGEMENT
+            //socket.close() was commented out because it ran too fast and did not allow to emit the other events that have to be emitted previously.
+            // However, in the future the socket will never be closed.
+            // socket.close()
         }
     }, [room])
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
@@ -6,9 +5,7 @@ import { Provider } from 'react-redux'
 import store from './store'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-    <React.StrictMode>
-        <Provider store={store}>
-            <App />
-        </Provider>
-    </React.StrictMode>
+    <Provider store={store}>
+        <App />
+    </Provider>
 )

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -43,8 +43,6 @@ const Play = () => {
                     throw new Error('Error creating room')
                 }
             } else {
-                console.log('Room created successfully')
-
                 const room = await response.json()
 
                 navigate('/game', {


### PR DESCRIPTION
This pull request introduces several key changes that aim to improve the gameplay experience and backend logic of our Pong game.

- Refactor Match Data Transfer Object (DTO): I have updated the CreateMatchDto to better reflect the game's scoring system. 

- Paddle Collision Logic: The collision logic for both the left and right paddles has been refined. Previously, the ball would rebound even if it had already passed the paddle's x-position but was still within the y-range of the paddle. The updated collision logic now correctly considers the position of the ball, ensuring it only bounces back when it has not yet exceeded the respective paddle in the x axis.

- Updated Score System: The PongService has seen changes in the scoring logic. I have removed the automatic game reset when a player reaches a score of 10 and instead shifted the game-over handling logic to the front-end component BoardGame.

- Front-end Changes: On the front-end side, the BoardGame component was updated to reflect the changes in scoring logic. Now, the game-over condition is triggered based on the gameOver status from the server. Also, the logic to save match data in the database has been added to the BoardGame component. 

- Room ID now passed along with User ID when leaving a room in pong.gateway.ts. Reduces reliance on array-like access of rooms, mitigating 'undefined' room issues.

- Logic change: Client leaving a room now broadcasts 'leftRoom' event to the room, not just the leaving client.

- Comment corrected from "COALITION LOGIQUE" to "COLLISION LOGIC".

- Unnecessary comments and logs removed in BoardGame.tsx and Play.tsx to clean up the codebase.

- Added 'otherPlayerHasLeftTheRoom' ref to handle the scenario where another player leaves the room in BoardGame.tsx.

- Implemented a new 'leftRoom' event listener in BoardGame.tsx. On triggering, it notifies the user and navigates back to '/play' after a delay.