### PR TITLE
muted cascade

### DIFF
--- a/backend/src/typeorm/channel-user-muted.entity.ts
+++ b/backend/src/typeorm/channel-user-muted.entity.ts
@@ -13,11 +13,16 @@ export class ChannelUserMuted {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne(() => Channel, (channel) => channel.muted, { cascade: true })
+    @ManyToOne(() => Channel, (channel) => channel.muted, {
+        onDelete: 'CASCADE',
+    })
     @JoinColumn({ name: 'channelId' })
     channel: Channel
 
-    @ManyToOne(() => User, (user) => user.muted)
+    @ManyToOne(() => User, (user) => user.muted, {
+        onDelete: 'CASCADE',
+    })
+	
     @JoinColumn({ name: 'userId' })
     user: User
 


### PR DESCRIPTION
When you delete a channel with a muted user, with option onDelete: 'CASCADE', in muted user entity now the channel can be deleted