### PR TITLE
banned menu

### DIFF
--- a/frontend/src/components/chat/userBox/UserBox.tsx
+++ b/frontend/src/components/chat/userBox/UserBox.tsx
@@ -95,7 +95,7 @@ const UserBox = (props: UserBoxProps) => {
                     />
                 ) : null
             )}
-            <h2> banned </h2>
+            {props.bannedUsers.length > 0 ? <h2>banned</h2> : null}
             {props.bannedUsers.map((banUser) => (
                 <UserComponent
                     socket={props.socket}

--- a/frontend/src/components/chat/userBox/UserComponent.tsx
+++ b/frontend/src/components/chat/userBox/UserComponent.tsx
@@ -310,13 +310,19 @@ const UserComponent = ({
                             {toggleBlockUser}
                             {amIowner ? (
                                 <ul>
-                                    {isAdmin ? (
-                                        <li onClick={unsetAdmin}>
-                                            Remove admin
-                                        </li>
-                                    ) : (
-                                        <li onClick={setAdmin}>Set admin</li>
-                                    )}
+                                    {isAdmin
+                                        ? !isBanned &&
+                                          !isDM && (
+                                              <li onClick={unsetAdmin}>
+                                                  Remove admin
+                                              </li>
+                                          )
+                                        : !isBanned &&
+                                          !isDM && (
+                                              <li onClick={setAdmin}>
+                                                  Set admin
+                                              </li>
+                                          )}
                                     {!isBanned && !isDM && (
                                         <li onClick={kickUser}>Kick</li>
                                     )}
@@ -326,7 +332,7 @@ const UserComponent = ({
                                     {!isBanned && !isDM && (
                                         <li onClick={banUser}>Ban</li>
                                     )}
-                                    {!isMuted && (
+                                    {!isBanned && !isDM && !isMuted && (
                                         <li onClick={muteUser}>Mute</li>
                                     )}
                                 </ul>
@@ -334,15 +340,16 @@ const UserComponent = ({
                                 amIadmin &&
                                 !isOwner && (
                                     <ul>
-                                        {!isBanned && (
+                                        {!isBanned && !isDM && (
                                             <li onClick={kickUser}>Kick</li>
                                         )}
-                                        {isBanned ? (
+                                        {isBanned && !isDM && (
                                             <li onClick={unbanUser}>Unban</li>
-                                        ) : (
+                                        )}
+                                        {!isBanned && !isDM && (
                                             <li onClick={banUser}>Ban</li>
                                         )}
-                                        {!isMuted && (
+                                        {!isBanned && !isDM && !isMuted && (
                                             <li onClick={muteUser}>Mute</li>
                                         )}
                                     </ul>


### PR DESCRIPTION
If there is no banned user in channel banned title it's not showed.
If UserComponent is banned you can't set/unset admin, nor mute User.
The same if UserComponent is DM
If User is admin all implementation of the menu is equal than if user is owner