### PR TITLE
script: check if docker is running

### DIFF
--- a/scripts/create-env.sh
+++ b/scripts/create-env.sh
@@ -51,7 +51,17 @@ create_the_environment_file () {
 
 }
 
+is_docker_running () {
+	if ! docker ps 2> /dev/null 1> /dev/null
+	then
+		echo docker is not running
+		echo please launch docker to run this script
+		exit 1
+	fi
+}
+
 main () {
+	is_docker_running
 	is_environement_file_already_exist
 
 	ask_42_api_credentials


### PR DESCRIPTION
# script: check if docker is running

When we are creating the `.env` file, we need that docker is running to generate password.

So, first check if docker is running before to continue
