### PR TITLE
frontend: alert the user when the file is too large

### DIFF
--- a/frontend/src/components/profile/UserInformation.tsx
+++ b/frontend/src/components/profile/UserInformation.tsx
@@ -129,6 +129,8 @@ const UserInformation = () => {
 
                 if (response.status === 201) {
                     setShouldReloadUserData(true)
+                } else if (response.status === 413) {
+                    alert('your file is too big')
                 } else {
                     console.error(
                         'Error loading profile image:',


### PR DESCRIPTION
# Frontend: alert the user when the file is too large

In production, nginx send a 413 http error when the user try to send a too large file.

Manage the 413 with a alert window
